### PR TITLE
Add the "loopback" flag. (#1)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -163,6 +163,11 @@ Client.prototype.packet = function(packet, opts){
   opts = opts || {};
   var self = this;
 
+  if ('open' != this.conn.readyState) {
+    debug('ignoring packet write %j', packet);
+    return;
+  }
+
   // this writes to the actual connection
   function writeToEngine(encodedPackets) {
     if (opts.volatile && !self.conn.transport.writable) return;
@@ -171,15 +176,23 @@ Client.prototype.packet = function(packet, opts){
     }
   }
 
-  if ('open' == this.conn.readyState) {
+  if (opts.loopback) {
+    debug('writing loopback packet %j', packet);
+    // handle loopback packets as though they came in off the wire.
+    if (opts.preEncoded) { // a broadcast pre-encodes a packet
+      for (var i = 0; i < packet.length; i++) {
+        this.decoder.add(packet[i]);
+      }
+    } else { // no broadcasting, no need to decode
+      this.ondecoded(packet);
+    }
+  } else {
     debug('writing packet %j', packet);
     if (!opts.preEncoded) { // not broadcasting, need to encode
       this.encoder.encode(packet, writeToEngine); // encode, then write results to engine
     } else { // a broadcast pre-encodes a packet
       writeToEngine(packet);
     }
-  } else {
-    debug('ignoring packet write %j', packet);
   }
 };
 

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -30,6 +30,7 @@ exports.events = [
  */
 
 exports.flags = [
+  'loopback',
   'json',
   'volatile',
   'local'

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -37,6 +37,7 @@ exports.events = [
  */
 
 var flags = [
+  'loopback',
   'json',
   'volatile',
   'broadcast',
@@ -153,6 +154,10 @@ Socket.prototype.emit = function(ev){
   if (typeof args[args.length - 1] === 'function') {
     if (this._rooms.length || this.flags.broadcast) {
       throw new Error('Callbacks are not supported when broadcasting');
+    }
+
+    if (this.flags.loopback) {
+      throw new Error('Callbacks are not supported when emitting loopback messages');
     }
 
     debug('emitting packet with ack id %d', this.nsp.ids);


### PR DESCRIPTION
The "loopback" flag is used to emit messages on the local endpoint of
a socket; e.g., allowing the server to send a message to the server's
handler directly.

This is especially useful in conjunction with rooms, as it allows the
server to proactively trigger behavior for each socket in a room without
having to maintain a separate list of said sockets or relying on the
client endpoint to trigger the behavior.


### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


