### PR TITLE
Revert socketio bump and add dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
+    ignore:
+      # Has breaking changes that require careful rollout. https://socket.io/blog/engine-io-4-release/#Major-breaking-changes
+      - dependency-name: "engine.io"
+        versions: ["4.x"]
     reviewers:
       - "kr-project/sre"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "debug": "~4.1.1",
-    "engine.io": "~4.0.0",
+    "engine.io": "~3.4.2",
     "has-binary2": "~2.0.0",
     "socket.io-adapter": "kr-project/socket.io-adapter",
     "socket.io-client": "2.3.0",


### PR DESCRIPTION
PTAL: @chrisleck @vaskevich 

It's going to be a bit of an ordeal to roll this out safely: https://socket.io/blog/engine-io-4-release/#Major-breaking-changes.

### The kind of change this PR does introduce

* [ ] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [x] other

### Current behaviour


### New behaviour


### Other information (e.g. related issues)


